### PR TITLE
Fix sead init hidden directory handling

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -854,19 +854,45 @@ sead status
     }]);
     
     if (!overwrite) {
+      await ensureHiddenSeadCore(projectPath);
       console.log(chalk.blue('ℹ️  Skipping .sead-core installation (keeping existing)'));
     } else {
       console.log(chalk.blue('🔄 Removing existing .sead-core...'));
       await fs.remove(seadCoreDest);
       await fs.copy(seadCoreSrc, seadCoreDest);
+      await ensureHiddenSeadCore(projectPath);
       console.log(chalk.green('✅ SEAD resources copied successfully'));
     }
   } else {
     await fs.copy(seadCoreSrc, seadCoreDest);
+    await ensureHiddenSeadCore(projectPath);
     console.log(chalk.green('✅ SEAD resources copied successfully'));
   }
-  
+
   // Resources are now available directly in .sead-core directory
+}
+
+async function ensureHiddenSeadCore(projectPath) {
+  const hiddenDir = path.join(projectPath, '.sead-core');
+  const visibleDir = path.join(projectPath, 'sead-core');
+
+  const [hiddenExists, visibleExists] = await Promise.all([
+    fs.pathExists(hiddenDir),
+    fs.pathExists(visibleDir),
+  ]);
+
+  if (!hiddenExists && visibleExists) {
+    // Legacy installers created a visible sead-core directory; move it to the hidden location.
+    await fs.move(visibleDir, hiddenDir, { overwrite: true });
+    console.log(chalk.yellow('ℹ️  Moved legacy `sead-core` folder to `.sead-core`'));
+    return;
+  }
+
+  if (hiddenExists && visibleExists) {
+    // Clean up duplicates so future commands always target the hidden directory.
+    await fs.remove(visibleDir);
+    console.log(chalk.yellow('ℹ️  Removed duplicate `sead-core` folder (using `.sead-core`)'));
+  }
 }
 
 async function runAgentBasedCatalogGeneration(options) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sead-method-core",
-  "version": "1.3.4",
+  "version": "1.3.5-beta.4",
   "description": "Specification Enforced Agentic Agile Development - A hybrid methodology preventing AI agent drift through catalog-based constraints with comprehensive external asset integration",
   "main": "cli.js",
   "bin": {


### PR DESCRIPTION
## Summary
- ensure sead init normalizes the SEAD assets into the hidden .sead-core directory
- migrate or clean up legacy visible sead-core folders automatically
- bump package version to 1.3.5-beta.4 for new beta publish

## Testing
- npm test
- node cli.js init (manual smoke test in temporary directory)
